### PR TITLE
Check if the system supports lpstat

### DIFF
--- a/runtime/plugin/hardcopy.lua
+++ b/runtime/plugin/hardcopy.lua
@@ -57,7 +57,17 @@ end
 
 local function unix_fallback_printing_system()
 
-  -- Todo: add check to see if the system supports fallback printing
+  -- TODO: check if printer_interface_command an accurate argument name?
+  local function check_fallback_printing_support(printer_interface_command)
+
+    check = vim.fn.system('command -v lpstat')
+
+    if check ~= '' then
+      return true
+    else
+      return false
+    end
+  end
 
   local function parse_raw_printer_list(lpstat_output)
     local printer_names = {}
@@ -69,10 +79,13 @@ local function unix_fallback_printing_system()
     return printer_names
   end
 
-  local raw_printer_list = vim.fn.system('lpstat -v')
-  local parsed_printer_list = parse_raw_printer_list(raw_printer_list)
-  
-  error("Not yet implemented")
+  if check_fallback_printing_support then
+    local raw_printer_list = vim.fn.system('lpstat -v')
+    local parsed_printer_list = parse_raw_printer_list(raw_printer_list)
+    return parsed_printer_list
+  else
+    error("The system does not support fallback printing")
+  end
 
 end
 
@@ -100,4 +113,3 @@ vim.api.nvim_create_user_command('Hardcopy', function(cmd)
     print_or_export_with_the_fallback_systems()
   end
 end, {desc = 'Dumps the buffer content into an HTML and opens the browser for viewing or printing', nargs = '?'})
-


### PR DESCRIPTION
Hi @CarbonHeartDev,

Is this what you meant when you said you wanted to test if the system supports lpstat?
the function check_fallback_printing_support [should work with POSIX systems](https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script), please let me know if you meant something else.

Thank you! 